### PR TITLE
include hidden/sensitive fields

### DIFF
--- a/mara_metabase/metadata.py
+++ b/mara_metabase/metadata.py
@@ -27,7 +27,7 @@ def update_metadata() -> bool:
     print(f'.. Waiting {seconds} seconds')
     time.sleep(seconds)
 
-    metadata = client.get(f'/api/database/{dwh_db_id}/metadata')
+    metadata = client.get(f'/api/database/{dwh_db_id}/metadata?include_hidden=true')
     data_sets = {data_set.name: data_set for data_set in mara_schema.config.data_sets()}
 
     for table in metadata['tables']:


### PR DESCRIPTION
include hidden/sensitive fields on initial metadata request. This fields are required by metrics generator. Only necessary on newer metabase versions (> 0.36.0).