### PR TITLE
Bug fix in ACL sync

### DIFF
--- a/mara_metabase/acl.py
+++ b/mara_metabase/acl.py
@@ -13,7 +13,9 @@ def sync():
     client = MetabaseClient()
 
     metabase_groups = {group['name']: group['id'] for group in client.get('/api/permissions/group')}
-    metabase_users = {user['email']: user['id'] for user in client.get('/api/user')}
+    metabase_users = {user['email']: user['id'] for user in client.get('/api/user?include_deactivated=true')}
+    deactivated_metabase_users = {user['email']: user['id'] for user
+                                  in client.get('/api/user?include_deactivated=true') if not user['is_active']}
     mara_roles = set()
     mara_users = set()
 
@@ -38,6 +40,8 @@ def sync():
                     if email not in metabase_users:
                         print(client.post('/api/user', metabase_user))
                     else:
+                        if email in deactivated_metabase_users:
+                            print(client.put(f'/api/user/{metabase_users[email]}/reactivate', metabase_user))
                         print(client.put(f'/api/user/{metabase_users[email]}', metabase_user))
 
     # delete groups that don't exist as roles in Mara


### PR DESCRIPTION
It was not possible to re-add users that were previously deleted.

![image](https://user-images.githubusercontent.com/1379194/99419543-84370500-28fc-11eb-999a-eeea5ea25841.png)

`Error while syncing to Metabase: 400: {"errors":{"email": "Email address already in use."}}`