### PR TITLE
Fix for metabase API change

### DIFF
--- a/mara_metabase/metadata.py
+++ b/mara_metabase/metadata.py
@@ -22,6 +22,7 @@ def update_metadata() -> bool:
     for db in all_dbs:
         if db['name'] == config.metabase_data_db_name():
             dwh_db_id = db['id']
+            break
 
     if not dwh_db_id:
         print(f'Database {config.metabase_data_db_name()} not found in Metabase', file=sys.stderr)


### PR DESCRIPTION
Metabase changed the API response sometimes between 38 and 41 and `client.get('/api/database/')` returns a `{"data": [{db info}, {...}]}` instead of the previous `[{db info}, {...}]`.